### PR TITLE
Fixed flushbar dependency for Flutter 1.12

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,8 @@ dependencies:
   dio: 3.0.8
 
   # A flexible widget for user notification.
-  flushbar: ^1.9.1
+  # Do not upgrade until Flutter 1.15 is on stable channel
+  flushbar: 1.9.1
 
   # Material Dialog
   material_dialog: ^0.0.9


### PR DESCRIPTION
Fixes #47 for current Flutter stable.

flushbar 1.10.X does not work with Flutter 1.12 so we need to remove the ^ to fix the dependency to 1.9.1