### PR TITLE
upgraded flushbar package to 1.10.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,9 +54,7 @@ dependencies:
   # A powerful Http client for Dart
   dio: 3.0.8
 
-  # A flexible widget for user notification.
-  # Do not upgrade until Flutter 1.15 is on stable channel
-  flushbar: 1.9.1
+  flushbar: ^1.10.4
 
   # Material Dialog
   material_dialog: ^0.0.9


### PR DESCRIPTION
As per @zubairehman code comment
  # A flexible widget for user notification.
  # Do not upgrade until Flutter 1.15 is on stable channel

I thing as  flutter has already released the its version to 1.17.1.
we are safe to update the flushbar to ^1.10.4