### PR TITLE
feat: init code base

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -23,7 +23,8 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdkVersion 34
+    namespace "com.iotecksolutions.todoapp"
+    compileSdkVersion 36
 
     lintOptions {
         disable 'InvalidPackage'
@@ -33,7 +34,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.iotecksolutions.todoapp"
         minSdkVersion flutter.minSdkVersion
-        targetSdkVersion 34
+        targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -45,6 +46,13 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = '17'
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "com.android.application" version "8.6.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   # H
   http: ^0.13.5
   # I
-  intl: ^0.19.0
+  intl: ^0.20.2
   # J
   json_serializable: ^6.6.1
   # K


### PR DESCRIPTION
Bump Android build targets and toolchain versions and update intl dependency. Changes include: set application namespace and raise compileSdkVersion/targetSdkVersion to 36; enable Java 17 compatibility and set Kotlin jvmTarget to 17; upgrade Gradle wrapper to 8.7 and Android Gradle Plugin to 8.6.0 with Kotlin plugin 2.1.0; bump intl dependency to ^0.20.2. These updates align the project with newer Android/Gradle toolchains and dependency requirements.